### PR TITLE
(WIP) MacAppStoreから利用できるように修正

### DIFF
--- a/bin/child.plist
+++ b/bin/child.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.inherit</key>
+    <true/>
+  </dict>
+</plist>

--- a/bin/extinfo.plist
+++ b/bin/extinfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>ElectronTeamID</key>
+  <string>52QJ97GWTE</string>
+  <key>com.apple.security.application-groups</key>
+  <string>52QJ97GWTE.jp.nanasi.myukkurivoice</string>
+</dict>
+</plist>

--- a/bin/masbuild.sh
+++ b/bin/masbuild.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+electron-packager . myukkurivoice --platform=mas --arch=x64 --version=1.4.12 --icon=icns/myukkurivoice.icns --overwrite --ignore="(\.gitignore|\.gitmodules|docs|icns|README.md|vendor/aqk2k_mac|vendor/aqtk1-mac-eva|vendor/aqtk2-mac)" --asar.unpackDir=vendor --app-bundle-id="jp.nanasi.myukkurivoice" --app-category-type="public.app-category.utilities" --app-version="0.2.0" --build-version="0.2.0" --osx-sign --entitlements="bin/parent.plist" --entitlements-inherit="bin/child.plist" --identity="3rd Party Mac Developer Application: Taku Omi (52QJ97GWTE)" --extend-info="bin/extinfo.plist" 
+

--- a/bin/maspkg.sh
+++ b/bin/maspkg.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+productbuild --component "myukkurivoice-mas-x64/myukkurivoice.app" /Applications --sign "3rd Party Mac Developer Installer: Taku Omi (52QJ97GWTE)" "myukkurivoice-mas-x64/myukkurivoice.pkg"

--- a/bin/parent.plist
+++ b/bin/parent.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>ElectronTeamID</key>
+    <string>52QJ97GWTE</string>
+    <key>com.apple.security.application-groups</key>
+    <string>52QJ97GWTE.jp.nanasi.myukkurivoice</string>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+    <key>com.apple.security.device.audio-video-bridging</key>
+    <true/>
+    <key>com.apple.security.temporary-exception.sbpl</key>
+    <string>(allow mach-lookup (global-name-regex #"^org.chromium.Chromium.rohitfork.[0-9]+$"))</string>
+  </dict>
+</plist>


### PR DESCRIPTION
- 作業用
- アプリ作成用のシェルを追加
- 使いやすくするためだったが、使用しているライブラリの署名が通らない